### PR TITLE
override add/subtract method for providing like DateTime interface.

### DIFF
--- a/lib/Time/Piece/Plus.pm
+++ b/lib/Time/Piece/Plus.pm
@@ -185,6 +185,57 @@ sub mysql_datetime {
     return $self->strftime("%Y-%m-%d %H:%M:%S");
 }
 
+sub add {
+    my ($self, @args) = @_;
+    return $self->SUPER::add(@args) if @args <= 1;
+
+    my %args = @args;
+    my $seconds = $self->_calc_seconds(%args);
+    $self = $self->SUPER::add($seconds);
+
+    $self = $self->add_months($args{months}) if $args{months};
+    $self = $self->add_years($args{years})   if $args{years};
+
+    $self;
+}
+
+sub subtract {
+    my ($self, @args) = @_;
+    return $self->SUPER::subtract(@args) if @args <= 1;
+
+    my %args = @args;
+    my $seconds = $self->_calc_seconds(%args);
+    $self = $self->SUPER::subtract($seconds);
+
+    $self = $self->add_months(-1 * $args{months}) if $args{months};
+    $self = $self->add_years(-1 * $args{years})   if $args{years};
+
+    $self;
+}
+
+sub _calc_seconds {
+    my $self = shift;
+
+    state $validator = Data::Validator->new(
+        seconds => {isa => 'Int', optional => 1},
+        minutes => {isa => 'Int', optional => 1},
+        hours   => {isa => 'Int', optional => 1},
+        days    => {isa => 'Int', optional => 1},
+        months  => {isa => 'Int', optional => 1},
+        years   => {isa => 'Int', optional => 1},
+    );
+    my $args = $validator->validate(@_);
+
+    my $seconds = 0;
+    $seconds += $args->{seconds}              if exists $args->{seconds};
+    $seconds += ONE_MINUTE * $args->{minutes} if exists $args->{minutes};
+    $seconds += ONE_HOUR   * $args->{hours}   if exists $args->{hours};
+    $seconds += ONE_DAY    * $args->{days}    if exists $args->{days};
+
+    $seconds;
+}
+
+
 1;
 __END__
 

--- a/t/10_add.t
+++ b/t/10_add.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+
+use Time::Piece::Plus;
+
+my $sometime = "2011-11-26 01:15:20";
+my $datetime_format = "%Y-%m-%d %H:%M:%S";
+my $time = Time::Piece::Plus->strptime($sometime, $datetime_format);
+
+subtest original => sub {
+    my $added = $time->add(10);
+    is($added->strftime($datetime_format) => "2011-11-26 01:15:30", "correctly added");
+};
+
+subtest add_days => sub {
+    my $added = $time->add(days => 1);
+    is($added->strftime($datetime_format) => "2011-11-27 01:15:20", "correctly added");
+};
+
+subtest add_month => sub {
+    my $added = $time->add(months => 1);
+    is($added->strftime($datetime_format) => "2011-12-26 01:15:20", "correctly added");
+};
+
+subtest add_year => sub {
+    my $added = $time->add(years => 1);
+    is($added->strftime($datetime_format) => "2012-11-26 01:15:20", "correctly added");
+};
+
+subtest add_all => sub {
+    my $added = $time->add(years => 1, months => 1, days => 1, hours => 1, seconds => 1, minutes => 1);
+    is($added->strftime($datetime_format) => "2012-12-27 02:16:21", "correctly added");
+};
+
+done_testing;

--- a/t/11_subtract.t
+++ b/t/11_subtract.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+
+use Time::Piece::Plus;
+
+my $sometime = "2011-11-26 01:15:20";
+my $datetime_format = "%Y-%m-%d %H:%M:%S";
+my $time = Time::Piece::Plus->strptime($sometime, $datetime_format);
+
+subtest original => sub {
+    my $subtracted = $time->subtract(10);
+    is($subtracted->strftime($datetime_format) => "2011-11-26 01:15:10", "correctly subtracted");
+};
+
+subtest subtract_days => sub {
+    my $subtracted = $time->subtract(days => 1);
+    is($subtracted->strftime($datetime_format) => "2011-11-25 01:15:20", "correctly subtracted");
+};
+
+subtest subtract_month => sub {
+    my $subtracted = $time->subtract(months => 1);
+    is($subtracted->strftime($datetime_format) => "2011-10-26 01:15:20", "correctly subtracted");
+};
+
+subtest subtract_year => sub {
+    my $subtracted = $time->subtract(years => 1);
+    is($subtracted->strftime($datetime_format) => "2010-11-26 01:15:20", "correctly subtracted");
+};
+
+subtest subtract_all => sub {
+    my $subtracted = $time->subtract(years => 1, months => 1, days => 1, hours => 1, seconds => 1, minutes => 1);
+    is($subtracted->strftime($datetime_format) => "2010-10-25 00:14:19", "correctly subtracted");
+};
+
+done_testing;


### PR DESCRIPTION
I want to use add/subtract method like DateTime.

Then I overrided `add` and `subtract` method providing interface like DateTime.
These methods don't change object itself. This is difference from DateTime.

This feature doesn't break original behavior of these methods.

If you like this. Merge it.
